### PR TITLE
use a splitter to prevent rebuilding all nwis_data branches

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,7 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(site_info, state, parameter) {
+  #site_info <- filter(sites_info, state_cd == state)
   message(sprintf('Retrieving data for %s-%s', state, site_info$site_no))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/_targets.R
+++ b/_targets.R
@@ -12,7 +12,7 @@ source('1_fetch/src/get_site_data.R')
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI', 'IL')
+states <- c('WI','MN','MI', 'IL', 'IN', 'IA')
 parameter <- c('00060')
 
 # Targets
@@ -27,7 +27,8 @@ list(
 
   tar_map(
     values = tibble(state_abb = states),
-    tar_target(nwis_data, get_site_data(oldest_active_sites, state_abb, parameter))
+    tar_target(nwis_inventory, filter(oldest_active_sites, state_cd == state_abb)),
+    tar_target(nwis_data, get_site_data(nwis_inventory, state_abb, parameter))
     # Insert step for tallying data here
     # Insert step for plotting data here
   ),


### PR DESCRIPTION
Allows only building IA and IN targets when they are added instead of all states